### PR TITLE
Switch from node-sass to sass

### DIFF
--- a/vorto-dashboard/README.md
+++ b/vorto-dashboard/README.md
@@ -126,7 +126,7 @@ You can use the basic structre of a thing and define the attributes like this:
 > **Note** That the `"definition": "org.eclipse.vorto:Topology:1.0.0"` is the most important part since it defines this element as the root.
 <br />
 
-In order to add containers that hold entities, simply create another meta-model that holds similar content to the root (e.g. empyt features etc.).
+In order to add containers that hold entities, simply create another meta-model that holds similar content to the root (e.g. empty features etc.).
 Make sure to define the `references` and `referencedBy` fields in the attributes in order to tell the dashboard the structure.
 
 ```json

--- a/vorto-dashboard/package.json
+++ b/vorto-dashboard/package.json
@@ -46,10 +46,11 @@
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
     "reselect": "^4.0.0",
+    "typescript": "^4.2.3",
     "yarn": "^1.17.3"
   },
   "devDependencies": {
-    "node-sass": "4.6.1",
+    "sass": "^1.32.8",
     "node-sass-chokidar": "^1.3.5",
     "npm-run-all": "4.1.2",
     "react-scripts": "^3.1.1"


### PR DESCRIPTION
https://sass-lang.com/blog/libsass-is-deprecated#how-do-i-migrate4.6.1

Binary download is 404, and build fails on Utf8Value signature. 
`npm start` works with the `sass` module.